### PR TITLE
Update jquery.storelocator.js

### DIFF
--- a/js/jquery.storelocator.js
+++ b/js/jquery.storelocator.js
@@ -17,7 +17,7 @@ $.fn.storeLocator = function(options) {
       'zoomLevel': 12,
       'pinColor': 'fe7569',
       'pinTextColor': '000000',
-      'lengthUnit': 'km',
+      'lengthUnit': 'm',
       'storeLimit': 26,
       'distanceAlert': 60,
       'dataType': 'xml',


### PR DESCRIPTION
Corrected 'lengthUnit' option default value from 'm' (not recognized) to 'km'.

Add some checks to disable max distance if the 'maxDistance' variable is null, undefined or 0.

Created a new function called "start" and call it at the initialization process.

When the address input is blank and the form is submitted the start function is called to reinitialize the map. The alert box displaying "The input box was blank" as been removed.

Replaced tab indentations by spaces.
