### PR TITLE
prevents zoom reset while dragging the map

### DIFF
--- a/src/js/jquery.storelocator.js
+++ b/src/js/jquery.storelocator.js
@@ -1796,6 +1796,7 @@
 			// Determine the new origin addresss
 			var newAddress = new this.reverseGoogleGeocode(this);
 			newCenterCoords = new google.maps.LatLng(mappingObj.lat, mappingObj.lng);
+			newCenterCoords.setZoom(map.getZoom());
 			newAddress.geocode({'latLng': newCenterCoords}, function (data) {
 				if (data !== null) {
 					mappingObj.origin = addressInput = data.address;


### PR DESCRIPTION
When a user drags the map, this is reinitialized with the default zoom level, with a "flashing" map effect and with less location displayed. This happens with "dragSearch: true".