### PR TITLE
Prevents zoom reset while dragging the map

### DIFF
--- a/src/js/jquery.storelocator.js
+++ b/src/js/jquery.storelocator.js
@@ -1786,6 +1786,10 @@
          */
 		dragSearch: function(map) {
 			this.writeDebug('dragSearch',arguments);
+			
+			// Save the new zoom setting
+			this.settings.mapSettings.zoom = map.getZoom();
+			
 			var newCenter = map.getCenter(),
 				newCenterCoords,
 				_this = this;


### PR DESCRIPTION
After dragging, the map is reloaded with the default zoom and not the one set by the user.