### PR TITLE
#211 - Fix page numbers still displayed when there are no results

### DIFF
--- a/src/js/jquery.storelocator.js
+++ b/src/js/jquery.storelocator.js
@@ -2510,17 +2510,17 @@
 				$this.slideDown();
 			}
 
-			// Handle no results
-			if (_this.isEmptyObject(locationset) || locationset[0].result === 'none') {
-				_this.emptyResult();
-				return;
-			}
-
 			// Output page numbers if pagination setting is true
 			if (_this.settings.pagination === true) {
 				_this.paginationSetup(page);
 			}
 
+			// Handle no results
+			if (_this.isEmptyObject(locationset) || locationset[0].result === 'none') {
+				_this.emptyResult();
+				return;
+			}
+			
 			// Set up the modal window
 			_this.modalWindow();
 


### PR DESCRIPTION
This fixes #211.  Moved the handling of "no results" to happen after paginationSetup so that if the new locationset contains no locations then the pagination HTML is removed from the page instead of it still showing the page numbers along with "No Results" on the page.