### PR TITLE
Remove inline style for location for css classes

### DIFF
--- a/src/js/jquery.storelocator.js
+++ b/src/js/jquery.storelocator.js
@@ -2199,8 +2199,10 @@
 			});
 
 			// Re-add the list background colors
-			$('.' + this.settings.locationList + ' ul li:even').css('background', this.settings.listColor1);
-			$('.' + this.settings.locationList + ' ul li:odd').css('background', this.settings.listColor2);
+			
+			// UPDATED Changed inline style with custom class
+			$('.' + this.settings.locationList + ' ul li:even').removeClass().addClass(this.settings.listColor1);
+			$('.' + this.settings.locationList + ' ul li:odd').removeClass().addClass(this.settings.listColor2);
 		},
 
 		/**
@@ -2960,8 +2962,9 @@
 			_this.listClick(_this.map, infowindow, storeStart, page);
 
 			// Add the list li background colors - this wil be dropped in a future version in favor of CSS
-			$('.' + _this.settings.locationList + ' ul > li:even').css('background', _this.settings.listColor1);
-			$('.' + _this.settings.locationList + ' ul > li:odd').css('background', _this.settings.listColor2);
+			// Updated, added class instaed of inline style
+			$('.' + _this.settings.locationList + ' ul > li:even').removeClass().addClass(_this.settings.listColor1);
+			$('.' + _this.settings.locationList + ' ul > li:odd').removeClass().addClass(_this.settings.listColor2);
 
 			// Visible markers list
 			_this.visibleMarkersList(_this.map, markers);


### PR DESCRIPTION
Removed inline style for location list in favor of css classes.

The config listColor1 and listColor2 can be used as classname, example:

```js
            listColor1: 'list-even-bg',
            listColor2: 'list-odd-bg',
```